### PR TITLE
Add a lock-free persistent ring-buffer

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -15,7 +15,7 @@
  (modules rowex)
  (public_name rowex)
  (libraries logs)
- (ocamlopt_flags -O3 -unbox-closures -unbox-closures-factor 20)
+ (ocamlopt_flags -O3)
  (foreign_stubs
   (language c)
   (flags

--- a/lib/persistent.mli
+++ b/lib/persistent.mli
@@ -8,6 +8,10 @@ val memory_of_mmu : mmu -> memory
 val root_of_mmu : mmu -> [ `Rd | `Wr ] Addr.t
 val run : mmu -> 'a t -> 'a
 
+type ring = memory
+
+val rrun : ring -> 'a t -> 'a
+
 (** / **)
 
 external atomic_set_leuintnat
@@ -17,3 +21,7 @@ external atomic_set_leuintnat
 external atomic_get_leuintnat
   : memory -> int -> _ memory_order -> int
   = "caml_atomic_get_leuintnat" [@@noalloc]
+
+external to_memory
+  : (_, _, Bigarray.c_layout) Bigarray.Array1.t -> memory
+  = "caml_to_memory" [@@noalloc]

--- a/lib/rowex.ml
+++ b/lib/rowex.ml
@@ -1291,6 +1291,7 @@ module Ringbuffer = struct
         else return () )
 
   and _enqueue_retry ~order ~non_empty ring tail t_cycle entry e_idx =
+    Log.debug (fun m -> m "enqueue retry") ;
     let n = (1 lsl order) * 2 in
     let t_idx = map tail order n in
     let e_cycle = entry lor (2 * n - 1) in

--- a/lib/rowex.mli
+++ b/lib/rowex.mli
@@ -69,6 +69,7 @@ module Ringbuffer : sig
 
   val enqueue : order:order -> non_empty:bool -> [ `Rd | `Wr ] Addr.t -> int -> unit t
   val dequeue : order:order -> non_empty:bool -> [ `Rd | `Wr ] Addr.t -> int t
+  val peek : order:order -> non_empty:bool -> [ `Rd | `Wr ] Addr.t -> int t
 
   val order_of_int : int -> order
   val size_of_order : order -> int

--- a/lib/rowex.mli
+++ b/lib/rowex.mli
@@ -36,14 +36,19 @@ type 'c memory_order =
   | Relaxed : [< `Rd | `Wr ] memory_order
   | Seq_cst : [< `Rd | `Wr ] memory_order
   | Release : [< `Wr ] memory_order
+  | Acq_rel : [< `Rd | `Wr ] memory_order
+  | Acquire : [< `Rd ] memory_order
 
 type 'a t =
   | Atomic_get : [< `Rd ] memory_order * [> `Rd ] Addr.t * ([ `Atomic ], 'a) value -> 'a t
   | Atomic_set : [< `Wr ] memory_order * [> `Wr ] Addr.t * ([ `Atomic ], 'a) value * 'a -> unit t
-  | Fetch_add  : [< `Rd | `Wr ] memory_order * [> `Rd | `Wr ] Addr.t * ([ `Atomic ], int) value * int -> unit t
+  | Fetch_add  : [< `Rd | `Wr ] memory_order * [> `Rd | `Wr ] Addr.t * ([ `Atomic ], int) value * int -> int t
+  | Fetch_or   : [< `Rd | `Wr ] memory_order * [> `Rd | `Wr ] Addr.t * ([ `Atomic ], int) value * int -> int t
+  | Fetch_sub  : [< `Rd | `Wr ] memory_order * [> `Rd | `Wr ] Addr.t * ([ `Atomic ], int) value * int -> int t
   | Pause_intrinsic : unit t
   | Compare_exchange : [> `Rd | `Wr ] Addr.t *
-                       ([ `Atomic ], 'a) value * 'a * 'a * bool * [< `Rd | `Wr ] memory_order -> bool t
+                       ([ `Atomic ], 'a) value * 'a ref * 'a * bool * [< `Rd | `Wr ] memory_order
+                       * [< `Rd | `Wr ] memory_order -> bool t
   | Get : [> `Rd ] Addr.t * ('c, 'a) value -> 'a t
   | Allocate : string list * int -> [ `Rd | `Wr ] Addr.t t
   | Delete : _ Addr.t * int -> unit t
@@ -58,3 +63,13 @@ val pp : 'a t fmt
 val find : [ `Rd ] Addr.t -> key -> int t
 val insert : [ `Rd | `Wr ] Addr.t -> key -> int -> unit t
 val ctor : unit -> [ `Rd | `Wr ] Addr.t t
+
+module Ringbuffer : sig
+  type order = private int
+
+  val enqueue : order:order -> non_empty:bool -> [ `Rd | `Wr ] Addr.t -> int -> unit t
+  val dequeue : order:order -> non_empty:bool -> [ `Rd | `Wr ] Addr.t -> int t
+
+  val order_of_int : int -> order
+  val size_of_order : order -> int
+end

--- a/rowex.opam
+++ b/rowex.opam
@@ -17,7 +17,7 @@ depends: [
   "dune"        {>= "2.0.0"}
   "dune-configurator"
   "base-bytes"
-  "fmt"
+  "fmt"         {>= "0.8.7"}
   "alcotest"    {with-test}
   "base-unix"   {with-test}
   "mmap"        {with-test}

--- a/rowex.opam
+++ b/rowex.opam
@@ -23,6 +23,7 @@ depends: [
   "mmap"        {with-test}
   "base64"      {with-test}
   "bos"         {with-test}
+  "cmdliner"    {with-test}
 ]
 
 available: [ arch != "ppc64"

--- a/test/dune
+++ b/test/dune
@@ -8,6 +8,17 @@
  (modules persistent)
  (libraries mmap base64 rowex rowex.persistent unix alcotest bos))
 
+(executable
+ (name rb)
+ (modules rb fiber)
+ (libraries bos rresult fmt.tty logs.fmt fmt mmap base64 rowex
+   rowex.persistent unix))
+
+(executable
+ (name test_ring)
+ (modules test_ring)
+ (libraries unix))
+
 (rule
  (alias runtest)
  (package art)
@@ -23,3 +34,12 @@
   (:test persistent.exe))
  (action
   (run %{test} --color=always)))
+
+(rule
+ (alias runtest)
+ (package rowex)
+ (deps
+  (:test test_ring.exe)
+  (:rb rb.exe))
+ (action
+  (run %{test})))

--- a/test/dune
+++ b/test/dune
@@ -11,8 +11,8 @@
 (executable
  (name rb)
  (modules rb fiber)
- (libraries bos rresult fmt.tty logs.fmt fmt mmap base64 rowex
-   rowex.persistent unix))
+ (libraries cmdliner bos rresult fmt.tty fmt.cli logs.fmt logs.cli fmt mmap
+   base64 rowex rowex.persistent unix))
 
 (executable
  (name test_ring)

--- a/test/dune
+++ b/test/dune
@@ -19,6 +19,11 @@
  (modules test_ring)
  (libraries unix))
 
+(executable
+ (name ring)
+ (modules ring)
+ (libraries mmap base64 rowex rowex.persistent unix alcotest bos))
+
 (rule
  (alias runtest)
  (package art)
@@ -43,3 +48,11 @@
   (:rb rb.exe))
  (action
   (run %{test})))
+
+(rule
+ (alias runtest)
+ (package rowex)
+ (deps
+  (:test ring.exe))
+ (action
+  (run %{test} --color=always)))

--- a/test/fiber.ml
+++ b/test/fiber.ml
@@ -1,0 +1,138 @@
+type 'a t = ('a -> unit) -> unit
+
+let return x k = k x
+
+let ( >>> ) a b k = a (fun () -> b k)
+
+let ( >>= ) t f k = t (fun x -> f x k)
+
+let ( >>| ) t f k = t (fun x -> k (f x))
+
+let both a b =
+  a >>= fun a ->
+  b >>= fun b -> return (a, b)
+
+module Ivar = struct
+  type 'a state = Full of 'a | Empty of ('a -> unit) Queue.t
+
+  type 'a t = { mutable state : 'a state }
+
+  let create () = { state = Empty (Queue.create ()) }
+
+  let fill t x =
+    match t.state with
+    | Full _ -> failwith "Ivar.fill"
+    | Empty q ->
+        t.state <- Full x ;
+        Queue.iter (fun f -> f x) q
+
+  let read t k = match t.state with Full x -> k x | Empty q -> Queue.push k q
+end
+
+type 'a ivar = 'a Ivar.t
+
+module Future = struct
+  let wait = Ivar.read
+end
+
+let fork f k =
+  let ivar = Ivar.create () in
+  f () (fun x -> Ivar.fill ivar x) ;
+  k ivar
+
+let fork_and_join f g =
+  fork f >>= fun a ->
+  fork g >>= fun b -> both (Future.wait a) (Future.wait b)
+
+let fork_and_join_unit f g =
+  fork f >>= fun a ->
+  fork g >>= fun b -> Future.wait a >>> Future.wait b
+
+let rec parallel_map l ~f =
+  match l with
+  | [] -> return []
+  | x :: l ->
+      fork (fun () -> f x) >>= fun future ->
+      parallel_map l ~f >>= fun l ->
+      Future.wait future >>= fun x -> return (x :: l)
+
+let rec parallel_iter l ~f =
+  match l with
+  | [] -> return ()
+  | x :: l ->
+      fork (fun () -> f x) >>= fun future ->
+      parallel_iter l ~f >>= fun () -> Future.wait future
+
+let safe_close fd = try Unix.close fd with Unix.Unix_error _ -> ()
+
+let create_process prgn =
+  let out0, out1 = Unix.pipe () in
+  match Unix.fork () with
+  | 0 -> (
+      Unix.close out0 ;
+      let oc = Unix.out_channel_of_descr out1 in
+      try
+        Marshal.to_channel oc (prgn ()) [ Marshal.No_sharing ] ;
+        flush oc ;
+        Unix.close out1 ;
+        exit 0
+      with _ -> exit 127)
+  | pid ->
+      Unix.close out1 ;
+      (out0, pid)
+
+let concurrency = ref 4
+
+let running = Hashtbl.create ~random:false !concurrency
+
+let waiting_for_slot = Queue.create ()
+
+let set_concurrency n = concurrency := n
+
+let get_concurrency () = !concurrency
+
+let throttle () =
+  if Hashtbl.length running >= !concurrency
+  then (
+    let ivar = Ivar.create () in
+    Queue.push ivar waiting_for_slot ;
+    Ivar.read ivar)
+  else return ()
+
+let restart_throttle () =
+  while
+    Hashtbl.length running < !concurrency
+    && not (Queue.is_empty waiting_for_slot)
+  do
+    Ivar.fill (Queue.pop waiting_for_slot) ()
+  done
+
+let run_process prgn =
+  throttle () >>= fun () ->
+  let fd, pid = create_process prgn in
+  let ivar = Ivar.create () in
+  Hashtbl.add running pid ivar ;
+  Ivar.read ivar >>= fun status ->
+  let ic = Unix.in_channel_of_descr fd in
+  let res = Marshal.from_channel ic in
+  safe_close fd ;
+  match status with
+  | Unix.WEXITED 0 -> return (Ok res)
+  | Unix.WEXITED n -> return (Error n)
+  | Unix.WSIGNALED _ -> return (Error 255)
+  | Unix.WSTOPPED _ -> assert false
+
+let run fiber =
+  let result = ref None in
+  fiber (fun x -> result := Some x) ;
+  let rec loop () =
+    if Hashtbl.length running > 0
+    then (
+      let pid, status = Unix.wait () in
+      let ivar = Hashtbl.find running pid in
+      Hashtbl.remove running pid ;
+      Ivar.fill ivar status ;
+      restart_throttle () ;
+      loop ())
+    else match !result with Some x -> x | None -> failwith "fiber" in
+  loop ()

--- a/test/fiber.mli
+++ b/test/fiber.mli
@@ -1,0 +1,31 @@
+type 'a t
+
+type 'a ivar
+
+val return : 'a -> 'a t
+
+val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+
+val ( >>| ) : 'a t -> ('a -> 'b) -> 'b t
+
+val ( >>> ) : unit t -> unit t -> unit t
+
+val both : 'a t -> 'b t -> ('a * 'b) t
+
+val fork : (unit -> 'a t) -> 'a ivar t
+
+val fork_and_join : (unit -> 'a t) -> (unit -> 'b t) -> ('a * 'b) t
+
+val fork_and_join_unit : (unit -> unit t) -> (unit -> unit t) -> unit t
+
+val parallel_map : 'a list -> f:('a -> 'b t) -> 'b list t
+
+val parallel_iter : 'a list -> f:('a -> unit t) -> unit t
+
+val run_process : (unit -> 'a) -> ('a, int) result t
+
+val run : 'a t -> 'a
+
+val set_concurrency : int -> unit
+
+val get_concurrency : unit -> int

--- a/test/persistent.ml
+++ b/test/persistent.ml
@@ -24,8 +24,9 @@ let create filename =
   let len = 1_048_576 in
   let fd  = Unix.openfile filename Unix.[ O_CREAT; O_RDWR ] 0o644 in
   let _   = Unix.lseek fd len Unix.SEEK_SET in
-  let memory = Mmap.V1.map_file fd ~pos:0L Bigarray.char Bigarray.c_layout true [| len |] in
+  let memory = Mmap.V1.map_file fd ~pos:0L Bigarray.int Bigarray.c_layout true [| len |] in
   let memory = Bigarray.array1_of_genarray memory in
+  let memory = to_memory memory in
   let brk = size_of_word * 2 in
   atomic_set_leuintnat memory 0 Seq_cst brk ;
   let mmu = mmu_of_memory memory in

--- a/test/rb.ml
+++ b/test/rb.ml
@@ -1,0 +1,119 @@
+external random_seed : unit -> int array = "caml_sys_random_seed"
+
+let seed = "4EygbdYh+v35vvrmD9YYP4byT5E3H7lTeXJiIj+dQnc="
+let seed = Base64.decode_exn seed
+
+let seed =
+  let res = Array.make (String.length seed / 2) 0 in
+  for i = 0 to (String.length seed / 2) - 1 do
+    res.(i) <- (Char.code seed.[i * 2] lsl 8) lor Char.code seed.[(i * 2) + 1]
+  done;
+  res
+
+let () =
+  let random_seed = seed in
+  Fmt.pr "Random: %a.\n%!" Fmt.(Dump.array int) random_seed;
+  Random.full_init random_seed
+
+let reporter ppf =
+  let report src level ~over k msgf =
+    let k _ =
+      over () ;
+      k () in
+    let with_metadata header _tags k ppf fmt =
+      Format.kfprintf k ppf
+        ("%a[%a][%a]: " ^^ fmt ^^ "\n%!")
+        Logs_fmt.pp_header (level, header)
+        Fmt.(styled `Blue (fmt "%10d")) (Unix.getpid ())
+        Fmt.(styled `Magenta string)
+        (Logs.Src.name src) in
+    msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
+  { Logs.report }
+
+(*
+let () = Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ~utf_8:true ()
+let () = Logs.set_reporter (reporter Fmt.stdout)
+let () = Logs.set_level ~all:true (Some Logs.Debug)
+*)
+
+open Rowex
+open Persistent
+open Rresult
+
+let size_of_word = Sys.word_size / 8
+
+let create ~order filename =
+  let len = Ringbuffer.size_of_order order in
+  let fd  = Unix.openfile filename Unix.[ O_CREAT; O_RDWR ] 0o644 in
+  let _   = Unix.lseek fd len Unix.SEEK_SET in
+  let memory = Mmap.V1.map_file fd ~pos:0L Bigarray.int Bigarray.c_layout true [| len |] in
+  let memory = Bigarray.array1_of_genarray memory in
+  let memory = to_memory memory in
+  atomic_set_leuintnat memory (size_of_word * 0) Seq_cst 0 ;
+  atomic_set_leuintnat memory (size_of_word * 1) Seq_cst 0 ;
+  atomic_set_leuintnat memory (size_of_word * 2) Seq_cst (-1) ;
+  for i = 0 to (1 lsl ((order :> int) + 1)) - 1 do
+    atomic_set_leuintnat memory (size_of_word * (3 + i)) Seq_cst (-1)
+  done ;
+  Unix.close fd
+
+let load ~order filename =
+  let len = Ringbuffer.size_of_order order in
+  let fd  = Unix.openfile filename Unix.[ O_CREAT; O_RDWR ] 0o644 in
+  let _   = Unix.lseek fd len Unix.SEEK_SET in
+  let memory = Mmap.V1.map_file fd ~pos:0L Bigarray.int Bigarray.c_layout true [| len |] in
+  let memory = Bigarray.array1_of_genarray memory in
+  let memory = to_memory memory in
+  fd, memory
+
+let test_spsc ~(order:Ringbuffer.order) ?(len= Random.int (1 lsl (order :> int))) filename =
+  let lst = List.init len
+    (fun _ -> 1 + Random.int ((1 lsl (order :> int)) - 1)) in
+  let eoq = 0 in
+  let fiber0 () =
+    let fd, ring = load ~order filename in
+    let rec go fd acc =
+      Unix.fsync fd ;
+      let res = rrun ring (Ringbuffer.dequeue ~order ~non_empty:true (Addr.of_int_rdwr 0)) in
+      if res = eoq then List.rev acc else go fd (res :: acc) in
+    let res = go fd [] in Unix.close fd ; res in
+  let fiber1 () =
+    let fd, ring = load ~order filename in
+    let rec go fd lst = match lst with
+      | [] ->
+        rrun ring (Ringbuffer.enqueue ~order ~non_empty:false (Addr.of_int_rdwr 0) eoq) ;
+        Unix.fsync fd ; Unix.close fd
+      | hd :: tl ->
+        rrun ring (Ringbuffer.enqueue ~order ~non_empty:false (Addr.of_int_rdwr 0) hd) ;
+        Unix.fsync fd ; go fd tl in
+    go fd lst in
+  let open Fiber in
+  fork_and_join (fun () -> run_process fiber0) (fun () -> run_process fiber1) >>= function
+  | Ok lst', Ok () ->
+    if lst = lst'
+    then return (R.ok ())
+    else ( Fmt.epr "%s: Failure.\n%!" Sys.argv.(0)
+         ; Fmt.epr "- : @[<hov>%a@].\n%!" Fmt.(Dump.list int) lst
+         ; Fmt.epr "- : @[<hov>%a@].\n%!" Fmt.(Dump.list int) lst'
+         ; return (R.error_msgf "Failure") )
+  | Error exit, _ ->
+    return (R.error_msgf "Reader exits with %03d" exit)
+  | _, Error exit ->
+    return (R.error_msgf "Writer exits with %03d" exit)
+
+let main ?len order =
+  let open Bos in
+  OS.File.tmp "ring-%s" >>= fun path ->
+  Logs.debug (fun m -> m "Ring file: %a" Fpath.pp path) ;
+  create ~order (Fpath.to_string path) ;
+  Fiber.run (test_spsc ~order ?len (Fpath.to_string path))
+
+let () = match Sys.argv with
+  | [| _; order; |] ->
+    let order = Ringbuffer.order_of_int (int_of_string order) in
+    R.failwith_error_msg (main order)
+  | [| _; order; len |] ->
+    let order = Ringbuffer.order_of_int (int_of_string order) in
+    let len = int_of_string len in
+    R.failwith_error_msg (main ~len order)
+  | _ -> Fmt.epr "%s <order> [<len>]\n%!" Sys.argv.(0)

--- a/test/rb.ml
+++ b/test/rb.ml
@@ -13,9 +13,6 @@ let reporter ppf =
     msgf @@ fun ?header ?tags fmt -> with_metadata header tags k ppf fmt in
   { Logs.report }
 
-(*
-*)
-
 open Rowex
 open Persistent
 open Rresult

--- a/test/ring.ml
+++ b/test/ring.ml
@@ -1,0 +1,123 @@
+external random_seed : unit -> int array = "caml_sys_random_seed"
+
+let seed = "4EygbdYh+v35vvrmD9YYP4byT5E3H7lTeXJiIj+dQnc="
+let seed = Base64.decode_exn seed
+
+let seed =
+  let res = Array.make (String.length seed / 2) 0 in
+  for i = 0 to (String.length seed / 2) - 1 do
+    res.(i) <- (Char.code seed.[i * 2] lsl 8) lor Char.code seed.[(i * 2) + 1]
+  done;
+  res
+
+let () =
+  let random_seed = seed in
+  Fmt.pr "Random: %a.\n%!" Fmt.(Dump.array int) random_seed;
+  Random.full_init random_seed
+
+open Rowex
+open Persistent
+
+let size_of_word = Sys.word_size / 8
+
+let create ~order filename =
+  let len = Ringbuffer.size_of_order order in
+  let fd  = Unix.openfile filename Unix.[ O_CREAT; O_RDWR ] 0o644 in
+  let _   = Unix.lseek fd len Unix.SEEK_SET in
+  let memory = Mmap.V1.map_file fd ~pos:0L Bigarray.int Bigarray.c_layout true [| len |] in
+  let memory = Bigarray.array1_of_genarray memory in
+  let memory = to_memory memory in
+  atomic_set_leuintnat memory (size_of_word * 0) Seq_cst 0 ;
+  atomic_set_leuintnat memory (size_of_word * 1) Seq_cst 0 ;
+  atomic_set_leuintnat memory (size_of_word * 2) Seq_cst (-1) ;
+  for i = 0 to (1 lsl ((order :> int) + 1)) - 1 do
+    atomic_set_leuintnat memory (size_of_word * (3 + i)) Seq_cst (-1)
+  done ;
+  Unix.close fd
+
+let load ~order filename =
+  let filename = Fpath.to_string filename in
+  let len = Ringbuffer.size_of_order order in
+  let fd  = Unix.openfile filename Unix.[ O_CREAT; O_RDWR ] 0o644 in
+  let _   = Unix.lseek fd len Unix.SEEK_SET in
+  let memory = Mmap.V1.map_file fd ~pos:0L Bigarray.int Bigarray.c_layout true [| len |] in
+  let memory = Bigarray.array1_of_genarray memory in
+  let memory = to_memory memory in
+  fd, memory
+
+let order = Ringbuffer.order_of_int 15
+let zero = Addr.of_int_rdwr 0
+
+let random_filename = Lazy.from_fun @@ fun () ->
+  let filename = Rresult.R.failwith_error_msg (Bos.OS.File.tmp "ring-%s") in
+  create ~order (Fpath.to_string filename) ; filename
+
+let load ~order = function
+  | Some filename -> load ~order filename
+  | None -> load ~order (Lazy.force random_filename)
+
+let push ring v = rrun ring Ringbuffer.(enqueue ~order ~non_empty:false zero v)
+let pop ?(non_empty= false) ring = rrun ring Ringbuffer.(dequeue ~order ~non_empty zero)
+let peek ?(non_empty= false) ring = rrun ring Ringbuffer.(peek ~order ~non_empty zero)
+
+let test01 =
+  Alcotest.test_case "test01" `Quick @@ fun filename ->
+  let fd, ring = load ~order filename in
+  push ring 1 ;
+  push ring 2 ;
+  push ring 3 ;
+  push ring 4 ;
+  Alcotest.(check int) "1" (pop ring) 1 ;
+  Alcotest.(check int) "2" (pop ring) 2 ;
+  Alcotest.(check int) "3" (pop ring) 3 ;
+  Alcotest.(check int) "4" (pop ring) 4 ;
+  Unix.close fd
+;;
+
+let test02 =
+  Alcotest.test_case "test02" `Quick @@ fun filename ->
+  let fd, ring = load ~order filename in
+  push ring 1 ;
+  Alcotest.(check int) "1" (pop ring) 1 ;
+  Alcotest.(check int) "null" (pop ring) (lnot 0) ;
+  push ring 2 ;
+  Alcotest.(check int) "2" (pop ring) 2 ;
+  Alcotest.(check int) "null" (pop ring) (lnot 0) ;
+  Unix.close fd
+;;
+
+let test03 =
+  Alcotest.test_case "test03" `Quick @@ fun filename ->
+  let fd, ring = load ~order filename in
+  push ring 1 ;
+  Alcotest.(check int) "1" (peek ring) 1 ;
+  push ring 2 ;
+  Alcotest.(check int) "1" (peek ring) 1 ;
+  push ring 3 ;
+  Alcotest.(check int) "1" (peek ring) 1 ;
+  Alcotest.(check int) "1" (pop ring) 1 ;
+  Alcotest.(check int) "2" (peek ring) 2 ;
+  Alcotest.(check int) "2" (pop ring) 2 ;
+  Alcotest.(check int) "3" (peek ring) 3 ;
+  Alcotest.(check int) "3" (pop ring) 3 ;
+  Alcotest.(check int) "null" (peek ring) (lnot 0) ;
+  Unix.close fd
+;;
+
+open Cmdliner
+
+let filename =
+  let parser x = match Fpath.of_string x with
+    | Ok v when not (Sys.file_exists x) ->
+      create ~order (Fpath.to_string v) ; Ok v
+    | Ok v -> Rresult.R.error_msgf "%a already exists" Fpath.pp v
+    | Error _ as err -> err in
+  let pp ppf _ = Fmt.pf ppf "#ring" in
+  Arg.conv (parser, pp)
+
+let filename =
+  let doc = "The persistent ring file." in
+  Arg.(value & opt (some filename) None & info [ "ring" ] ~doc)
+
+let () = Alcotest.run_with_args "ring" filename
+           [ "simple", [ test01; test02; test03 ] ]

--- a/test/test_ring.ml
+++ b/test/test_ring.ml
@@ -10,14 +10,28 @@ let exit_failure = 1
 
 let properly_exited = function Unix.WEXITED 0 -> true | _ -> false
 
+let count = ref 0
+
+let show filename =
+  let ic = open_in filename in
+  let rec go ic = match input_line ic with
+    | line -> Format.printf "%s\n%!" line ; go ic
+    | exception End_of_file -> close_in ic in
+  go ic
+
 let run order len =
+  let filename = Format.asprintf "%02d-ring.log" !count in
+  incr count ;
+  let log = Unix.openfile filename Unix.[ O_RDWR; O_CREAT; O_TRUNC ] 0o644 in
   let pid =
     Unix.create_process_env "./rb.exe"
       [| "./rb.exe"; string_of_int order; string_of_int len |]
-      [||] Unix.stdin Unix.stdout Unix.stderr in
+      [||] Unix.stdin Unix.stdout log in
   let _, status = Unix.waitpid [] pid in
-  res := !res && properly_exited status ;
-  Format.printf ">>> ./rb.exe %d %d: %a.\n%!" order len pp_process_status status
+  Unix.close log ; res := !res && properly_exited status ;
+  Format.printf ">>> ./rb.exe %d %d: %a.\n%!" order len pp_process_status status ;
+  if not (properly_exited status)
+  then show filename
 
 let () =
   run 15 10 ;

--- a/test/test_ring.ml
+++ b/test/test_ring.ml
@@ -1,0 +1,26 @@
+let pp_process_status ppf = function
+  | Unix.WEXITED n -> Format.fprintf ppf "(WEXITED %d)" n
+  | Unix.WSIGNALED n -> Format.fprintf ppf "(WSIGNALED %d)" n
+  | Unix.WSTOPPED n -> Format.fprintf ppf "(WSTOPPED %d)" n
+
+let res = ref true
+
+let exit_success = 0
+let exit_failure = 1
+
+let properly_exited = function Unix.WEXITED 0 -> true | _ -> false
+
+let run order len =
+  let pid =
+    Unix.create_process_env "./rb.exe"
+      [| "./rb.exe"; string_of_int order; string_of_int len |]
+      [||] Unix.stdin Unix.stdout Unix.stderr in
+  let _, status = Unix.waitpid [] pid in
+  res := !res && properly_exited status ;
+  Format.printf ">>> ./rb.exe %d %d: %a.\n%!" order len pp_process_status status
+
+let () =
+  run 15 10 ;
+  run 15 100 ;
+  run 15 1000 ;
+  if !res then exit exit_success else exit exit_failure


### PR DESCRIPTION
This is an implementation of a lock-free ring-buffer (according this research paper: [SCQ](https://drops.dagstuhl.de/opus/volltexte/2019/11335/pdf/LIPIcs-DISC-2019-28.pdf)) with a stress-test which does a real parallelism (with `fork`) and let processors to schedule atomic operations.