### PR TITLE
Monolith

### DIFF
--- a/art.opam
+++ b/art.opam
@@ -22,4 +22,5 @@ depends: [
   "fmt"         {>= "0.8.7"}
   "alcotest"    {with-test}
   "crowbar"     {with-test}
+  "monolith"    {with-test}
 ]

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,3 +1,9 @@
 (executable
  (name fuzz)
+ (modules fuzz)
  (libraries art crowbar))
+
+(executable
+ (name monolith)
+ (modules monolith)
+ (libraries art monolith))

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -7,3 +7,11 @@
  (name monolith)
  (modules monolith)
  (libraries art monolith))
+
+(rule
+ (alias runtest)
+ (action (run ./fuzz.exe)))
+
+(rule
+ (alias monolith)
+ (action (run ./monolith.exe)))

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -10,8 +10,10 @@
 
 (rule
  (alias runtest)
- (action (run ./fuzz.exe)))
+ (action
+  (run ./fuzz.exe)))
 
 (rule
  (alias monolith)
- (action (run ./monolith.exe)))
+ (action
+  (run ./monolith.exe)))

--- a/fuzz/monolith.ml
+++ b/fuzz/monolith.ml
@@ -1,0 +1,48 @@
+open Monolith
+open PPrint
+
+module Map = Map.Make (struct type t = Art.key let compare (a : Art.key) (b : Art.key) =
+  String.compare (a :> string) (b :> string) end)
+
+let char_without_d0 () = match Gen.char () with
+  | '\000' -> Gen.reject ()
+  | chr -> chr
+
+let key =
+  easily_constructible
+    Gen.(fun () -> Art.unsafe_key (string (int 100) char_without_d0 ()))
+    (fun (key : Art.key) -> string (key :> string))
+
+let value = lt 16
+
+module type INDEX = sig
+  type t
+
+  val make : unit -> t
+  val insert : t -> Art.key -> int -> unit
+  val find_opt : t -> Art.key -> int option
+end
+
+module Make (R : INDEX) (C : INDEX) = struct
+  let run t fuel =
+    declare "make" (unit ^> t) R.make C.make;
+    declare "insert" (t ^> key ^> value ^> unit) R.insert C.insert;
+    declare "find_opt" (t ^> key ^> option value) R.find_opt C.find_opt;
+    main fuel
+end
+
+module Reference = struct
+  type t = (Art.key, int) Hashtbl.t
+
+  let make () = Hashtbl.create 0x100
+  let insert tbl key value = Hashtbl.add tbl key value
+  let find_opt tbl key = match Hashtbl.find tbl key with
+    | v -> Some v
+    | exception Not_found -> None
+end
+
+module Equivalence = Make (Reference) (struct include Art type t = int Art.t end)
+
+let () =
+  let t = declare_abstract_type () in
+  Equivalence.run t 5

--- a/fuzz/monolith.ml
+++ b/fuzz/monolith.ml
@@ -21,11 +21,13 @@ module type INDEX = sig
   val make : unit -> t
   val insert : t -> Art.key -> int -> unit
   val find_opt : t -> Art.key -> int option
+  val is_empty : t -> bool
 end
 
 module Make (R : INDEX) (C : INDEX) = struct
   let run t fuel =
     declare "make" (unit ^> t) R.make C.make;
+    declare "is_empty" (t ^> bool) R.is_empty C.is_empty;
     declare "insert" (t ^> key ^> value ^> unit) R.insert C.insert;
     declare "find_opt" (t ^> key ^> option value) R.find_opt C.find_opt;
     main fuel
@@ -35,6 +37,7 @@ module Reference = struct
   type t = (Art.key, int) Hashtbl.t
 
   let make () = Hashtbl.create 0x100
+  let is_empty tbl = Hashtbl.length tbl = 0
   let insert tbl key value = Hashtbl.add tbl key value
   let find_opt tbl key = match Hashtbl.find tbl key with
     | v -> Some v

--- a/lib/art.ml
+++ b/lib/art.ml
@@ -467,6 +467,8 @@ let maximum tree =
 
 let make () = ref empty_elt
 
+let is_empty v = !v == empty_elt
+
 let remove_child_n256
   : n256 record -> 'a elt ref -> 'a elt array -> char -> unit
   = fun record tree children chr ->

--- a/lib/art.mli
+++ b/lib/art.mli
@@ -39,6 +39,10 @@ val find_opt : 'a t -> key -> 'a option
 
 val pp : 'a Fmt.t -> 'a t Fmt.t
 
+val is_empty : 'a t -> bool
+(** [is_empty tree] returns [true] if [tree] is empty. Otherwise, it returns
+   [false]. *)
+
 val minimum : 'a t -> key * 'a
 (** Return the binding with the smallest {!key} in a given tree
    or raise [Invalid_argument] if the tree is empty. *)

--- a/rowex.opam
+++ b/rowex.opam
@@ -26,6 +26,7 @@ depends: [
   "cmdliner"
   "fpath"
   "mmap"
+  "crowbar" {>= "0.2" & with-test}
 ]
 available:
   arch != "ppc64" & arch != "arm32" & arch != "arm64" & arch != "x86_32"


### PR DESCRIPTION
This is a small example of `monolith` to complete the `crowbar` fuzzer (/cc @backtracking, @pascutto).