### PR TITLE
Delete the support of s390x

### DIFF
--- a/rowex.opam
+++ b/rowex.opam
@@ -29,7 +29,7 @@ depends: [
   "crowbar" {>= "0.2" & with-test}
 ]
 available:
-  arch != "ppc64" & arch != "arm32" & arch != "arm64" & arch != "x86_32"
+  arch != "ppc64" & arch != "arm32" & arch != "arm64" & arch != "x86_32" & arch != "s390x"
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/dinosaure/art.git"


### PR DESCRIPTION
`s390x` is a bit special for `rowex`, I don't have any clue about intrinsic on such platform. 